### PR TITLE
Use latest revision image that I built

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -233,7 +233,7 @@ spec:
           value: "false"
         - name: BASE_HREF
           value: /
-        image: argoproj/argoui:v2.2.1
+        image: mizzy/argoui:86efd1
         name: argo-ui
       serviceAccountName: argo-ui
 ---


### PR DESCRIPTION
With argoui:v2.2.1, logs shows nothing and Javascript console shows this error:

EventSource's response has a MIME type ("application/json") that is not "text/event-stream". Aborting the connection.

So I created a docker image from latest master revision of argoproj/argo-ui.

This image works fine.